### PR TITLE
Require subsequent buildpacks to specify build or launch metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea/
 build/
 .bin/
+bin/

--- a/README.md
+++ b/README.md
@@ -44,10 +44,9 @@ file that looks like the following:
     # Any valid semver constraint is acceptable.
     version = "0.1.0"
 
-    # The PHP Composer Dist buildpack supports some non-required metadata options.
-    # If neither metadata.build or metadata.launch is provided, or if both are
-    # set to false, this buildpack will contribute only during the build phase.
-    # All fields are OPTIONAL.
+    # The PHP Composer Dist buildpack requires some additional metadata options.
+    # If neither metadata.build or metadata.launch is provided, this buidpack will contribute
+    # an ignored layer
     [requires.metadata]
     
         # Setting the build flag to true will ensure that Composer
@@ -118,8 +117,3 @@ For more information, please reference the [composer docs](https://getcomposer.o
 ```shell
 COMPOSER=./somewhere/composer-other.json
 ```
-
-## TODO:
-- Add layer caching
-- Offline caching
-- Add SBOM support

--- a/build.go
+++ b/build.go
@@ -1,14 +1,15 @@
 package composer
 
 import (
+	"os"
+	"path/filepath"
+	"time"
+
 	"github.com/paketo-buildpacks/packit/v2"
 	"github.com/paketo-buildpacks/packit/v2/chronos"
 	"github.com/paketo-buildpacks/packit/v2/draft"
 	"github.com/paketo-buildpacks/packit/v2/postal"
 	"github.com/paketo-buildpacks/packit/v2/scribe"
-	"os"
-	"path/filepath"
-	"time"
 )
 
 // Note that Go 1.18 requires faux 0.21.0 (https://github.com/ryanmoran/faux/releases/tag/v0.21.0)
@@ -45,10 +46,6 @@ func Build(
 		}
 
 		composerLayer.Launch, composerLayer.Build = entryResolver.MergeLayerTypes("composer", context.Plan.Entries)
-
-		if !composerLayer.Launch && !composerLayer.Build {
-			composerLayer.Build = true
-		}
 
 		// version = "" is entirely fine
 		version, _ := entry.Metadata["version"].(string)

--- a/build_test.go
+++ b/build_test.go
@@ -2,6 +2,10 @@ package composer_test
 
 import (
 	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
 	. "github.com/onsi/gomega"
 	"github.com/paketo-buildpacks/composer"
 	"github.com/paketo-buildpacks/composer/fakes"
@@ -10,9 +14,6 @@ import (
 	"github.com/paketo-buildpacks/packit/v2/postal"
 	"github.com/paketo-buildpacks/packit/v2/scribe"
 	"github.com/sclevine/spec"
-	"os"
-	"path/filepath"
-	"testing"
 )
 
 func testBuild(t *testing.T, context spec.G, it spec.S) {
@@ -244,7 +245,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 			}
 		})
 
-		it("will contribute to the build phase only", func() {
+		it("will contribute an ignored layer", func() {
 			result, err := build(packit.BuildContext{
 				WorkingDir: workingDir,
 				CNBPath:    cnbDir,
@@ -268,7 +269,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 						BuildEnv:         packit.Environment{},
 						LaunchEnv:        packit.Environment{},
 						ProcessLaunchEnv: map[string]packit.Environment{},
-						Build:            true,
+						Build:            false,
 						Launch:           false,
 						Cache:            false,
 						Metadata: map[string]interface{}{
@@ -279,5 +280,4 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 			}))
 		})
 	})
-
 }

--- a/integration/default_app_test.go
+++ b/integration/default_app_test.go
@@ -66,7 +66,7 @@ func testDefaultApp(t *testing.T, context spec.G, it spec.S) {
 				WithPullPolicy("never").
 				WithBuildpacks(
 					buildpacks.PhpDist,
-					buildpacks.ComposerDist,
+					buildpacks.Composer,
 					buildpacks.BuildPlan,
 				).
 				WithEnv(env).

--- a/integration/init_test.go
+++ b/integration/init_test.go
@@ -29,9 +29,9 @@ var buildpackInfo struct {
 }
 
 var buildpacks struct {
-	BuildPlan    string `json:"build-plan"`
-	PhpDist      string `json:"php-dist"`
-	ComposerDist string
+	BuildPlan string `json:"build-plan"`
+	PhpDist   string `json:"php-dist"`
+	Composer  string
 }
 
 func TestIntegration(t *testing.T) {
@@ -66,7 +66,7 @@ func TestIntegration(t *testing.T) {
 	root, err := filepath.Abs("./..")
 	Expect(err).ToNot(HaveOccurred())
 
-	buildpacks.ComposerDist, err = buildpackStore.Get.
+	buildpacks.Composer, err = buildpackStore.Get.
 		WithVersion("1.2.3").
 		Execute(root)
 	Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
Require subsequent buildpacks to specify build or launch metadata

## Checklist
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
