### PR TITLE
Implement RFC 0050: Rename Buildpack

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -5,7 +5,7 @@ api = "0.7"
   homepage = "https://github.com/paketo-buildpacks/composer"
   id = "paketo-buildpacks/composer"
   keywords = ["php", "composer"]
-  name = "Paketo Composer Buildpack"
+  name = "Paketo Buildpack for Composer"
   sbom-formats = ["application/vnd.cyclonedx+json", "application/spdx+json", "application/vnd.syft+json"]
 
   [[buildpack.licenses]]


### PR DESCRIPTION
Renames 'Paketo Composer Buildpack' to 'Paketo Buildpack for Composer'.

Implements RFC 0050, https://github.com/paketo-buildpacks/rfcs/issues/233, for this buildpack.

Signed-off-by: Daniel Mikusa <dmikusa@vmware.com>
